### PR TITLE
Add PlatformIO Library Registry manifest file

### DIFF
--- a/ADS1147/library.json
+++ b/ADS1147/library.json
@@ -10,7 +10,7 @@
   },
   "dependencies":
   {
-    "name": "Watterott-digitalWriteFast",
+    "name": "digitalWriteFast",
     "frameworks": "arduino"
   },
   "frameworks": "arduino",

--- a/ADS1147/library.json
+++ b/ADS1147/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-ADS1147",
+  "name": "ADS1147",
   "keywords": "spi, driver, adc, analog, input, converter, signal",
   "description": "ADS1147 ADC (Analog-Digital-Converter)",
-  "include": "Arduino/ADS1147",
+  "include": "ADS1147",
   "repository":
   {
     "type": "git",

--- a/ADS1147/library.json
+++ b/ADS1147/library.json
@@ -1,0 +1,18 @@
+{
+  "name": "Watterott-ADS1147",
+  "keywords": "spi, driver, adc, analog, input, converter, signal",
+  "description": "ADS1147 ADC (Analog-Digital-Converter)",
+  "include": "Arduino/ADS1147",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "dependencies":
+  {
+    "name": "Watterott-digitalWriteFast",
+    "frameworks": "arduino"
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/ADS7846/library.json
+++ b/ADS7846/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-ADS7846",
+  "name": "ADS7846",
   "keywords": "spi, driver, touch",
   "description": "ADS7846/TSC2046 Touch-Controller",
-  "include": "Arduino/ADS7846",
+  "include": "ADS7846",
   "repository":
   {
     "type": "git",

--- a/ADS7846/library.json
+++ b/ADS7846/library.json
@@ -11,19 +11,19 @@
   "dependencies":
   [
     {
-      "name": "Watterott-digitalWriteFast",
+      "name": "digitalWriteFast",
       "frameworks": "arduino"
     },
     {
-      "name": "Watterott-GraphicsLib",
+      "name": "GraphicsLib",
       "frameworks": "arduino"
     },
     {
-      "name": "Watterott-MI0283QT2",
+      "name": "MI0283QT2",
       "frameworks": "arduino"
     },
     {
-      "name": "Watterott-MI0283QT9",
+      "name": "MI0283QT9",
       "frameworks": "arduino"
     }
   ],

--- a/ADS7846/library.json
+++ b/ADS7846/library.json
@@ -1,0 +1,32 @@
+{
+  "name": "Watterott-ADS7846",
+  "keywords": "spi, driver, touch",
+  "description": "ADS7846/TSC2046 Touch-Controller",
+  "include": "Arduino/ADS7846",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "dependencies":
+  [
+    {
+      "name": "Watterott-digitalWriteFast",
+      "frameworks": "arduino"
+    },
+    {
+      "name": "Watterott-GraphicsLib",
+      "frameworks": "arduino"
+    },
+    {
+      "name": "Watterott-MI0283QT2",
+      "frameworks": "arduino"
+    },
+    {
+      "name": "Watterott-MI0283QT9",
+      "frameworks": "arduino"
+    }
+  ],
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/DAC8760/library.json
+++ b/DAC8760/library.json
@@ -10,7 +10,7 @@
   },
   "dependencies":
   {
-    "name": "Watterott-digitalWriteFast",
+    "name": "digitalWriteFast",
     "frameworks": "arduino"
   },
   "frameworks": "arduino",

--- a/DAC8760/library.json
+++ b/DAC8760/library.json
@@ -1,0 +1,18 @@
+{
+  "name": "Watterott-DAC8760",
+  "keywords": "spi, driver, dac, analog, output, converter, signal",
+  "description": "DAC8760 DAC (Digital-Analog-Converter)",
+  "include": "Arduino/DAC8760",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "dependencies":
+  {
+    "name": "Watterott-digitalWriteFast",
+    "frameworks": "arduino"
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/DAC8760/library.json
+++ b/DAC8760/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-DAC8760",
+  "name": "DAC8760",
   "keywords": "spi, driver, dac, analog, output, converter, signal",
   "description": "DAC8760 DAC (Digital-Analog-Converter)",
-  "include": "Arduino/DAC8760",
+  "include": "DAC8760",
   "repository":
   {
     "type": "git",

--- a/DS1307/library.json
+++ b/DS1307/library.json
@@ -1,0 +1,13 @@
+{
+  "name": "Watterott-DS1307",
+  "keywords": "rtc, time, clock, i2c",
+  "description": "DS1307 RTC (Real-Time-Clock)",
+  "include": "Arduino/DS1307",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/DS1307/library.json
+++ b/DS1307/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-DS1307",
+  "name": "DS1307",
   "keywords": "rtc, time, clock, i2c",
   "description": "DS1307 RTC (Real-Time-Clock)",
-  "include": "Arduino/DS1307",
+  "include": "DS1307",
   "repository":
   {
     "type": "git",

--- a/DisplayI2C/library.json
+++ b/DisplayI2C/library.json
@@ -1,0 +1,24 @@
+{
+  "name": "Watterott-DisplayI2C",
+  "keywords": "i2c, graphics, display, lcd, driver",
+  "description": "MI0283QT-Adapter v2 + GLCD-Shield (I2C)",
+  "include": "Arduino/DisplayI2C",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "dependencies":
+  [
+    {
+      "name": "Watterott-DisplaySPI",
+      "frameworks": "arduino"
+    },
+    {
+      "name": "Watterott-GraphicsLib",
+      "frameworks": "arduino"
+    }
+  ],
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/DisplayI2C/library.json
+++ b/DisplayI2C/library.json
@@ -11,11 +11,11 @@
   "dependencies":
   [
     {
-      "name": "Watterott-DisplaySPI",
+      "name": "DisplaySPI",
       "frameworks": "arduino"
     },
     {
-      "name": "Watterott-GraphicsLib",
+      "name": "GraphicsLib",
       "frameworks": "arduino"
     }
   ],

--- a/DisplayI2C/library.json
+++ b/DisplayI2C/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-DisplayI2C",
+  "name": "DisplayI2C",
   "keywords": "i2c, graphics, display, lcd, driver",
   "description": "MI0283QT-Adapter v2 + GLCD-Shield (I2C)",
-  "include": "Arduino/DisplayI2C",
+  "include": "DisplayI2C",
   "repository":
   {
     "type": "git",

--- a/DisplaySPI/library.json
+++ b/DisplaySPI/library.json
@@ -1,0 +1,28 @@
+{
+  "name": "Watterott-DisplaySPI",
+  "keywords": "spi, graphics, display, lcd, driver",
+  "description": "MI0283QT-Adapter v2 + GLCD-Shield (SPI)",
+  "include": "Arduino/DisplaySPI",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "dependencies":
+  [
+    {
+      "name": "Watterott-DisplayI2C",
+      "frameworks": "arduino"
+    },
+    {
+      "name": "Watterott-digitalWriteFast",
+      "frameworks": "arduino"
+    },
+    {
+      "name": "Watterott-GraphicsLib",
+      "frameworks": "arduino"
+    }
+  ],
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/DisplaySPI/library.json
+++ b/DisplaySPI/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-DisplaySPI",
+  "name": "DisplaySPI",
   "keywords": "spi, graphics, display, lcd, driver",
   "description": "MI0283QT-Adapter v2 + GLCD-Shield (SPI)",
-  "include": "Arduino/DisplaySPI",
+  "include": "DisplaySPI",
   "repository":
   {
     "type": "git",

--- a/DisplaySPI/library.json
+++ b/DisplaySPI/library.json
@@ -11,15 +11,15 @@
   "dependencies":
   [
     {
-      "name": "Watterott-DisplayI2C",
+      "name": "DisplayI2C",
       "frameworks": "arduino"
     },
     {
-      "name": "Watterott-digitalWriteFast",
+      "name": "digitalWriteFast",
       "frameworks": "arduino"
     },
     {
-      "name": "Watterott-GraphicsLib",
+      "name": "GraphicsLib",
       "frameworks": "arduino"
     }
   ],

--- a/GraphicsLib/library.json
+++ b/GraphicsLib/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-GraphicsLib",
+  "name": "GraphicsLib",
   "keywords": "graphics",
   "description": "General Grahipcs Library",
-  "include": "Arduino/GraphicsLib",
+  "include": "GraphicsLib",
   "repository":
   {
     "type": "git",

--- a/GraphicsLib/library.json
+++ b/GraphicsLib/library.json
@@ -1,0 +1,13 @@
+{
+  "name": "Watterott-GraphicsLib",
+  "keywords": "graphics",
+  "description": "General Grahipcs Library",
+  "include": "Arduino/GraphicsLib",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/MI0283QT2/library.json
+++ b/MI0283QT2/library.json
@@ -1,0 +1,24 @@
+{
+  "name": "Watterott-MI0283QT2",
+  "keywords": "driver, graphics, display",
+  "description": "MI0283QT-2 Display (HX8347D, SPI)",
+  "include": "Arduino/MI0283QT2",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "dependencies":
+  [
+    {
+      "name": "Watterott-digitalWriteFast",
+      "frameworks": "arduino"
+    },
+    {
+      "name": "Watterott-GraphicsLib",
+      "frameworks": "arduino"
+    }
+  ],
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/MI0283QT2/library.json
+++ b/MI0283QT2/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-MI0283QT2",
+  "name": "MI0283QT2",
   "keywords": "driver, graphics, display",
   "description": "MI0283QT-2 Display (HX8347D, SPI)",
-  "include": "Arduino/MI0283QT2",
+  "include": "MI0283QT2",
   "repository":
   {
     "type": "git",

--- a/MI0283QT2/library.json
+++ b/MI0283QT2/library.json
@@ -11,11 +11,11 @@
   "dependencies":
   [
     {
-      "name": "Watterott-digitalWriteFast",
+      "name": "digitalWriteFast",
       "frameworks": "arduino"
     },
     {
-      "name": "Watterott-GraphicsLib",
+      "name": "GraphicsLib",
       "frameworks": "arduino"
     }
   ],

--- a/MI0283QT9/library.json
+++ b/MI0283QT9/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-MI0283QT9",
+  "name": "MI0283QT9",
   "keywords": "driver, graphics, display",
   "description": "MI0283QT-9 / -9A / -11 Display (ILI9341, SPI)",
-  "include": "Arduino/MI0283QT9",
+  "include": "MI0283QT9",
   "repository":
   {
     "type": "git",

--- a/MI0283QT9/library.json
+++ b/MI0283QT9/library.json
@@ -11,11 +11,11 @@
   "dependencies":
   [
     {
-      "name": "Watterott-digitalWriteFast",
+      "name": "digitalWriteFast",
       "frameworks": "arduino"
     },
     {
-      "name": "Watterott-GraphicsLib",
+      "name": "GraphicsLib",
       "frameworks": "arduino"
     }
   ],

--- a/MI0283QT9/library.json
+++ b/MI0283QT9/library.json
@@ -1,0 +1,24 @@
+{
+  "name": "Watterott-MI0283QT9",
+  "keywords": "driver, graphics, display",
+  "description": "MI0283QT-9 / -9A / -11 Display (ILI9341, SPI)",
+  "include": "Arduino/MI0283QT9",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "dependencies":
+  [
+    {
+      "name": "Watterott-digitalWriteFast",
+      "frameworks": "arduino"
+    },
+    {
+      "name": "Watterott-GraphicsLib",
+      "frameworks": "arduino"
+    }
+  ],
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ ArdOSC           - OSC for RedFly
 CANdiy_Shield    - CANdiy-Shield (CAN-Bus)
 DAC8760          - DAC8760 DAC (Digital-Analog-Converter)
 digitalWriteFast - Fast pin access for AVR
-DisplayI2C       - MI0283QT-Adapter v2 + GLCD-Shield (SPI)
-DisplaySPI       - MI0283QT-Adapter v2 + GLCD-Shield (I2C)
+DisplayI2C       - MI0283QT-Adapter v2 + GLCD-Shield (I2C)
+DisplaySPI       - MI0283QT-Adapter v2 + GLCD-Shield (SPI)
 DS1307           - DS1307 RTC (Real-Time-Clock)
 GraphicsLib      - General Grahipcs Library
 LCD_BackPack     - LCD-BackPack (for HD44780 compatible displays)

--- a/RV8523/library.json
+++ b/RV8523/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-RV8523",
+  "name": "RV8523",
   "keywords": "i2c, driver, rtc, time, clock",
   "description": "RV-8523 RTC (Real-Time-Clock)",
-  "include": "Arduino/RV8523",
+  "include": "RV8523",
   "repository":
   {
     "type": "git",

--- a/RV8523/library.json
+++ b/RV8523/library.json
@@ -1,0 +1,13 @@
+{
+  "name": "Watterott-RV8523",
+  "keywords": "i2c, driver, rtc, time, clock",
+  "description": "RV-8523 RTC (Real-Time-Clock)",
+  "include": "Arduino/RV8523",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/RedFly/library.json
+++ b/RedFly/library.json
@@ -1,0 +1,13 @@
+{
+  "name": "Watterott-RedFly",
+  "keywords": "wifi, wlan",
+  "description": "RedFly-Shield (WiFi/WLAN)",
+  "include": "Arduino/RedFly",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/RedFly/library.json
+++ b/RedFly/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-RedFly",
+  "name": "RedFly",
   "keywords": "wifi, wlan",
   "description": "RedFly-Shield (WiFi/WLAN)",
-  "include": "Arduino/RedFly",
+  "include": "RedFly",
   "repository":
   {
     "type": "git",

--- a/RotaryEncoder/library.json
+++ b/RotaryEncoder/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-RotaryEncoder",
+  "name": "RotaryEncoder",
   "keywords": "input, signal, driver",
   "description": "Rotary Encoder",
-  "include": "Arduino/RotaryEncoder",
+  "include": "RotaryEncoder",
   "repository":
   {
     "type": "git",

--- a/RotaryEncoder/library.json
+++ b/RotaryEncoder/library.json
@@ -10,7 +10,7 @@
   },
   "dependencies":
   {
-    "name": "Watterott-digitalWriteFast",
+    "name": "digitalWriteFast",
     "frameworks": "arduino"
   },
   "frameworks": "arduino",

--- a/RotaryEncoder/library.json
+++ b/RotaryEncoder/library.json
@@ -1,0 +1,18 @@
+{
+  "name": "Watterott-RotaryEncoder",
+  "keywords": "input, signal, driver",
+  "description": "Rotary Encoder",
+  "include": "Arduino/RotaryEncoder",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "dependencies":
+  {
+    "name": "Watterott-digitalWriteFast",
+    "frameworks": "arduino"
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/S65L2F50/library.json
+++ b/S65L2F50/library.json
@@ -1,0 +1,24 @@
+{
+  "name": "Watterott-S65L2F50",
+  "keywords": "spi, display, graphics",
+  "description": "S65 L2F50 Display (SPI)",
+  "include": "Arduino/S65L2F50",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "dependencies":
+  [
+    {
+      "name": "Watterott-digitalWriteFast",
+      "frameworks": "arduino"
+    },
+    {
+      "name": "Watterott-GraphicsLib",
+      "frameworks": "arduino"
+    }
+  ],
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/S65L2F50/library.json
+++ b/S65L2F50/library.json
@@ -11,11 +11,11 @@
   "dependencies":
   [
     {
-      "name": "Watterott-digitalWriteFast",
+      "name": "digitalWriteFast",
       "frameworks": "arduino"
     },
     {
-      "name": "Watterott-GraphicsLib",
+      "name": "GraphicsLib",
       "frameworks": "arduino"
     }
   ],

--- a/S65L2F50/library.json
+++ b/S65L2F50/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-S65L2F50",
+  "name": "S65L2F50",
   "keywords": "spi, display, graphics",
   "description": "S65 L2F50 Display (SPI)",
-  "include": "Arduino/S65L2F50",
+  "include": "S65L2F50",
   "repository":
   {
     "type": "git",

--- a/S65LPH88/library.json
+++ b/S65LPH88/library.json
@@ -1,0 +1,24 @@
+{
+  "name": "Watterott-S65LPH88",
+  "keywords": "spi, display, graphics",
+  "description": "S65 LPH88 Display (SPI)",
+  "include": "Arduino/S65LPH88",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "dependencies":
+  [
+    {
+      "name": "Watterott-digitalWriteFast",
+      "frameworks": "arduino"
+    },
+    {
+      "name": "Watterott-GraphicsLib",
+      "frameworks": "arduino"
+    }
+  ],
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/S65LPH88/library.json
+++ b/S65LPH88/library.json
@@ -11,11 +11,11 @@
   "dependencies":
   [
     {
-      "name": "Watterott-digitalWriteFast",
+      "name": "digitalWriteFast",
       "frameworks": "arduino"
     },
     {
-      "name": "Watterott-GraphicsLib",
+      "name": "GraphicsLib",
       "frameworks": "arduino"
     }
   ],

--- a/S65LPH88/library.json
+++ b/S65LPH88/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-S65LPH88",
+  "name": "S65LPH88",
   "keywords": "spi, display, graphics",
   "description": "S65 LPH88 Display (SPI)",
-  "include": "Arduino/S65LPH88",
+  "include": "S65LPH88",
   "repository":
   {
     "type": "git",

--- a/S65LS020/library.json
+++ b/S65LS020/library.json
@@ -1,0 +1,24 @@
+{
+  "name": "Watterott-S65LS020",
+  "keywords": "spi, display, graphics",
+  "description": "S65 LS020 Display (SPI)",
+  "include": "Arduino/S65LS020",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "dependencies":
+  [
+    {
+      "name": "Watterott-digitalWriteFast",
+      "frameworks": "arduino"
+    },
+    {
+      "name": "Watterott-GraphicsLib",
+      "frameworks": "arduino"
+    }
+  ],
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/S65LS020/library.json
+++ b/S65LS020/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-S65LS020",
+  "name": "S65LS020",
   "keywords": "spi, display, graphics",
   "description": "S65 LS020 Display (SPI)",
-  "include": "Arduino/S65LS020",
+  "include": "S65LS020",
   "repository":
   {
     "type": "git",

--- a/S65LS020/library.json
+++ b/S65LS020/library.json
@@ -11,11 +11,11 @@
   "dependencies":
   [
     {
-      "name": "Watterott-digitalWriteFast",
+      "name": "digitalWriteFast",
       "frameworks": "arduino"
     },
     {
-      "name": "Watterott-GraphicsLib",
+      "name": "GraphicsLib",
       "frameworks": "arduino"
     }
   ],

--- a/SSD1331/library.json
+++ b/SSD1331/library.json
@@ -11,11 +11,11 @@
   "dependencies":
   [
     {
-      "name": "Watterott-digitalWriteFast",
+      "name": "digitalWriteFast",
       "frameworks": "arduino"
     },
     {
-      "name": "Watterott-GraphicsLib",
+      "name": "GraphicsLib",
       "frameworks": "arduino"
     }
   ],

--- a/SSD1331/library.json
+++ b/SSD1331/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-SSD1331",
+  "name": "SSD1331",
   "keywords": "spi, display, graphics, oled",
   "description": "OLED-Display (SSD1331, SPI)",
-  "include": "Arduino/SSD1331",
+  "include": "SSD1331",
   "repository":
   {
     "type": "git",

--- a/SSD1331/library.json
+++ b/SSD1331/library.json
@@ -1,0 +1,24 @@
+{
+  "name": "Watterott-SSD1331",
+  "keywords": "spi, display, graphics, oled",
+  "description": "OLED-Display (SSD1331, SPI)",
+  "include": "Arduino/SSD1331",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "dependencies":
+  [
+    {
+      "name": "Watterott-digitalWriteFast",
+      "frameworks": "arduino"
+    },
+    {
+      "name": "Watterott-GraphicsLib",
+      "frameworks": "arduino"
+    }
+  ],
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/digitalWriteFast/library.json
+++ b/digitalWriteFast/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-digitalWriteFast",
+  "name": "digitalWriteFast",
   "keywords": "io, driver",
   "description": "Fast pin access for AVR",
-  "include": "Arduino/digitalWriteFast",
+  "include": "digitalWriteFast",
   "repository":
   {
     "type": "git",

--- a/digitalWriteFast/library.json
+++ b/digitalWriteFast/library.json
@@ -1,0 +1,13 @@
+{
+  "name": "Watterott-digitalWriteFast",
+  "keywords": "io, driver",
+  "description": "Fast pin access for AVR",
+  "include": "Arduino/digitalWriteFast",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}

--- a/mSD_Shield/library.json
+++ b/mSD_Shield/library.json
@@ -1,8 +1,8 @@
 {
-  "name": "Watterott-mSD_Shield",
+  "name": "mSD_Shield",
   "keywords": "display, microsd, rtc",
   "description": "mSD-Shield (Display, microSD, RTC)",
-  "include": "Arduino/mSD_Shield",
+  "include": "mSD_Shield",
   "repository":
   {
     "type": "git",

--- a/mSD_Shield/library.json
+++ b/mSD_Shield/library.json
@@ -1,0 +1,13 @@
+{
+  "name": "Watterott-mSD_Shield",
+  "keywords": "display, microsd, rtc",
+  "description": "mSD-Shield (Display, microSD, RTC)",
+  "include": "Arduino/mSD_Shield",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/watterott/Arduino-Libs.git"
+  },
+  "frameworks": "arduino",
+  "platforms": "atmelavr"
+}


### PR DESCRIPTION
- Fix two lines in README.md pertaining DisplayI2C and DisplaySPI
- Add library.json files for a number of libraries; this allows the libraries to be managed 
  from within PlatformIO (see http://platformio.org/)