### PR TITLE
Change digitalReadFast to properly return HIGH or LOW.

### DIFF
--- a/digitalWriteFast/digitalWriteFast.h
+++ b/digitalWriteFast/digitalWriteFast.h
@@ -346,7 +346,7 @@ if (__builtin_constant_p(P) && __builtin_constant_p(V)) { \
 #define digitalReadFast(P) ( (int) __digitalReadFast((P)) )
 #define __digitalReadFast(P ) \
   (__builtin_constant_p(P) ) ? ( \
-  ( BIT_READ(*__digitalPinToPINReg(P), __digitalPinToBit(P))) ) : \
+  ( BIT_READ(*__digitalPinToPINReg(P), __digitalPinToBit(P))) ? HIGH:LOW ) : \
   digitalRead((P))
 #else
 #define digitalReadFast digitalRead

--- a/digitalWriteFast/examples/Example/Example.ino
+++ b/digitalWriteFast/examples/Example/Example.ino
@@ -7,21 +7,31 @@
 
 #include <digitalWriteFast.h>
 
+#define PIN 10
 
 void setup()
 {
-  byte pin;
+  volatile byte pin;
 
-  //set pin mode for pin 10
-  pinModeFast(10, INPUT);
-  pinModeFast(10, OUTPUT);
+  //set pin mode for pin PIN
+  pinModeFast(PIN, INPUT);
+  pinModeFast(PIN, OUTPUT);
 
-  //set pin state for pin 10
-  digitalWriteFast(10, LOW);
-  digitalWriteFast(10, HIGH);
+  //set pin state for pin PIN
+  digitalWriteFast(PIN, LOW);
+  digitalWriteFast(PIN, HIGH);
 
-  //get pin state of pin 10
-  pin = digitalReadFast(10);
+  //get pin state of pin PIN
+  pin = digitalReadFast(PIN);  // save a proper high/low value
+
+  // demonstrate optimization of tests
+  if (digitalReadFast(PIN) == HIGH) {
+    digitalWriteFast(PIN, LOW);
+  }
+  if (digitalReadFast(PIN) == LOW) {
+    digitalWriteFast(PIN, HIGH);
+  }
+
 }
 
 


### PR DESCRIPTION
Also extend the Example to actually store the read result so that
this can be confirmed.  Add some if() statements to demonstrate
that the new code doesn't incease the execution time of the
common "test" of a pin.

See http://forum.arduino.cc/index.php?topic=581534.0

~~~
  //get pin state of pin PIN
  pin = digitalReadFast(PIN);  // save a proper high/low value
 1bc:   83 b1           in      r24, 0x03       ; 3
 1be:   82 fb           bst     r24, 2
 1c0:   88 27           eor     r24, r24
 1c2:   80 f9           bld     r24, 0
 1c4:   89 83           std     Y+1, r24        ; 0x01

  // demonstrate optimization of tests
  if (digitalReadFast(PIN) == HIGH) {
 1c6:   1a 99           sbic    0x03, 2 ; 3
    digitalWriteFast(PIN, LOW);
 1c8:   2a 98           cbi     0x05, 2 ; 5
  }
  if (digitalReadFast(PIN) == LOW) {
 1ca:   1a 9b           sbis    0x03, 2 ; 3
    digitalWriteFast(PIN, HIGH);
 1cc:   2a 9a           sbi     0x05, 2 ; 5
~~~