### PR TITLE
Add support for the Atmega168 chip

### DIFF
--- a/digitalWriteFast/digitalWriteFast.h
+++ b/digitalWriteFast/digitalWriteFast.h
@@ -258,9 +258,10 @@
 (((P) >= 8 && (P) <= 11) ? (P) - 4 : (((P) >= 18 && (P) <= 21) ? 25 - (P) : (((P) == 0) ? 2 : (((P) == 1) ? 3 : (((P) == 2) ? 1 : (((P) == 3) ? 0 : (((P) == 4) ? 4 : (((P) == 6) ? 7 : (((P) == 13) ? 7 : (((P) == 14) ? 3 : (((P) == 15) ? 1 : (((P) == 16) ? 2 : (((P) == 17) ? 0 : (((P) == 22) ? 1 : (((P) == 23) ? 0 : (((P) == 24) ? 4 : (((P) == 25) ? 7 : (((P) == 26) ? 4 : (((P) == 27) ? 5 : 6 )))))))))))))))))))
 
 
-// --- Arduino Uno ---
+// --- Arduino Uno and similar boards based on ATmega168 ---
 #elif (defined(ARDUINO_AVR_UNO) || \
        defined(ARDUINO_AVR_DUEMILANOVE) || \
+       defined(__AVR_ATmega168__) || \
        defined(__AVR_ATmega328__) || \
        defined(__AVR_ATmega328P__) || \
        defined(__AVR_ATmega328PB__))

--- a/digitalWriteFast/library.properties
+++ b/digitalWriteFast/library.properties
@@ -1,5 +1,5 @@
 name=digitalWriteFast
-version=1.0.0
+version=1.0.1
 author=Watterott
 maintainer=Watterott
 sentence=Fast pin access for AVR microcontrollers


### PR DESCRIPTION
Adds the define so that the macros used for the Atmega328 are used for the Atmega168 as well.